### PR TITLE
Correct file name of A(a)rduino.h file

### DIFF
--- a/src/pms.h
+++ b/src/pms.h
@@ -2,7 +2,7 @@
 #ifndef _PMS_H_
 #define _PMS_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <tribool.h>
 #include <pmsConfig.h>
 

--- a/src/tribool.h
+++ b/src/tribool.h
@@ -1,7 +1,7 @@
 #ifndef _tribool_h_
 #define _tribool_h_
 
-#include <arduino.h>
+#include <Arduino.h>
 
 class tribool;
 


### PR DESCRIPTION

Correct file name of A(a)rduino.h file.
Be aware that some OS correctly check upper and lower leter in file name.