### PR TITLE
Added esp32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It is based on [jbanaszczyk/Pms5003](https://github.com/jbanaszczyk/Pms5003) lib
 ## Features
 
 * Supports all Plantover Pmsx003 features (sleep/wake up, passive/active modes), based on PMS5003,
+* supports ESP8266 and ESP32 based boards
 * Probably works fine with PMS7003(tested) and PMS3003(not tested),
 * Highly customizable:
   * Uses any serial communication library,
@@ -37,7 +38,15 @@ Use the code: https://github.com/riverscn/pmsx003/tree/master/examples/Simple01
 
 #include <pms.h>
 
-Pmsx003 pms(D3, D4);
+// if using ESP8266 board
+#define PMSx003_RX_PIN D6 // should match the label printed on your board
+#define PMSx003_TX_PIN D5 // should match the label printed on your board
+
+//if using ESP32 board, use number value as aliases are not defined for the board
+#define PMSx003_RX_PIN 12 // if connected to D12 of your board (aka GPIO12)
+#define PMSx003_TX_PIN 13 // if connected to D13 of your board (aka GPIO13)
+
+Pmsx003 pms(PMSx003_TX_PIN, PMSx003_RX_PIN);
 
 ////////////////////////////////////////
 

--- a/src/pms.cpp
+++ b/src/pms.cpp
@@ -60,7 +60,12 @@ Pmsx003::Pmsx003(int8_t swsRX, int8_t swsTX) : passive(tribool(unknown)), sleep(
 #if defined PMS_DYNAMIC
 	begin();
 #endif
+#if defined PMS_SOFTSERIAL
 	this->_pmsSerial = new SoftwareSerial(swsRX, swsTX);
+#elif defined PMS_HARDSERIAL
+	this->_pmsSerial = &Serial2;
+	this->_pmsSerial->begin(9600, SERIAL_8N1, swsRX, swsTX);
+#endif
 };
 
 Pmsx003::~Pmsx003() {

--- a/src/pms.h
+++ b/src/pms.h
@@ -28,7 +28,9 @@ private:
 
 #if defined PMS_SOFTSERIAL
 	SoftwareSerial* _pmsSerial;
-#endif  
+#elif defined PMS_HARDSERIAL
+	HardwareSerial* _pmsSerial;
+#endif
 
 public:
 	enum PmsStatus : uint8_t {

--- a/src/pms.h
+++ b/src/pms.h
@@ -11,7 +11,7 @@
 // Pin 2: GND
 
 // Using SoftSerial:
-//   Pin 4: int8_t swsTX 
+//   Pin 4: int8_t swsTX
 //   Pin 5: int8_t swsRX
 
 class Pmsx003 {
@@ -28,7 +28,9 @@ private:
 
 #if defined PMS_SOFTSERIAL
 	SoftwareSerial* _pmsSerial;
-#endif  
+#elif defined PMS_HARDSERIAL
+	HardwareSerial* _pmsSerial;
+#endif
 
 public:
 	enum PmsStatus : uint8_t {

--- a/src/pmsConfig.h
+++ b/src/pmsConfig.h
@@ -3,17 +3,21 @@
 
 ////////////////////////////////////////////
 
-// Use one of: 
+// Use one of:
 // it depends on Serial Library (and serial pin connection)
 
-#if not defined(PMS_SOFTSERIAL)
-#define PMS_SOFTSERIAL
+#if defined(ESP32)
+  #define PMS_HARDSERIAL
+#elif defined(ESP8266)
+  #define PMS_SOFTSERIAL
+#else
+  #define PMS_SOFTSERIAL
 #endif
 
 ////////////////////////////////////////////
 
 // Use PMS_DYNAMIC to be C++ strict
-// Without PMS_DYNAMIC: 
+// Without PMS_DYNAMIC:
 //   con: Pmsx003 related object should be defined as global variable (C style): Pmsx003 pms;
 //   con: It can not be initialized inside constructor. It is too early, serial ports and other pins will be redefined by Arduino bootloader
 //   con: It has to be initialzed within setup() - see examples: uses of begin()
@@ -33,8 +37,12 @@
 
 ////////////////////////////////////////////
 
-#if defined PMS_SOFTSERIAL
-#include <SoftwareSerial.h>
+#if defined(PMS_SOFTSERIAL)
+  #include <SoftwareSerial.h>
+#elif defined(PMS_HARDSERIAL)
+  #include <HardwareSerial.h>
+#else
+  #include <SoftwareSerial.h>
 #endif
 
 ////////////////////////////////////////////

--- a/src/pmsConfig.h
+++ b/src/pmsConfig.h
@@ -3,11 +3,15 @@
 
 ////////////////////////////////////////////
 
-// Use one of: 
+// Use one of:
 // it depends on Serial Library (and serial pin connection)
 
-#if not defined(PMS_SOFTSERIAL)
-#define PMS_SOFTSERIAL
+#if defined(ESP32)
+  #define PMS_HARDSERIAL
+#elif defined(ESP8266)
+  #define PMS_SOFTSERIAL
+#else
+  #define PMS_SOFTSERIAL
 #endif
 
 ////////////////////////////////////////////
@@ -33,8 +37,12 @@
 
 ////////////////////////////////////////////
 
-#if defined PMS_SOFTSERIAL
-#include <SoftwareSerial.h>
+#if defined(PMS_SOFTSERIAL)
+  #include <SoftwareSerial.h>
+#elif defined(PMS_HARDSERIAL)
+  #include <HardwareSerial.h>
+#else
+  #include <SoftwareSerial.h>
 #endif
 
 ////////////////////////////////////////////


### PR DESCRIPTION
SoftwareSerial has been replace by HardwareSerial on ESP32 based board. I added conditional import to be able to handle both platform and updated the doc to reflect those changes 

Tested on (platformio board id):
1. ESP8266 d1_mini 
2. ESP32 esp32doit-devkit-v1

connected to Plantower 7003 sensor